### PR TITLE
Add response variable name for ParsePkgFn

### DIFF
--- a/collector/pkg/component/analyzer/network/protocol/protocol_parser.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol_parser.go
@@ -370,7 +370,7 @@ func (message *PayloadMessage) ReadUntilCRLF(from int) (offset int, data []byte)
 }
 
 type FastFailFn func(message *PayloadMessage) bool
-type ParsePkgFn func(message *PayloadMessage) (bool, bool)
+type ParsePkgFn func(message *PayloadMessage) (success bool, complete bool)
 type PairMatch func(requests []*PayloadMessage, response *PayloadMessage) int
 
 type ProtocolParser struct {


### PR DESCRIPTION
Add response variable name for ParsePkgFn(#382)

Signed-off-by: blue-troy <12729455+blue-troy@users.noreply.github.com>